### PR TITLE
[add] added jmh microbenchmark, changed addDocuments to make usage of…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *
 !/**/
 !**/*.java
+!**/*.xml
 !**/*.jar
 !**/*.md
 !.gitignore

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
 		<maven.compiler.target>8</maven.compiler.target>
 		<maven.test.source>8</maven.test.source>
 		<maven.test.target>8</maven.test.target>
+		<jmh.version>1.21</jmh.version>
+		<maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+		<maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+		<maven-build-helper-plugin.version>1.12</maven-build-helper-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -60,9 +64,15 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>3.0.1</version>
+			<version>3.1.0</version>
 		</dependency>
 	</dependencies>
 
@@ -79,6 +89,27 @@
 	</distributionManagement>
 	<build>
 		<plugins>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${maven-build-helper-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/test/perf</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
@@ -94,11 +125,28 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+
+						<configuration>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>org.openjdk.jmh</groupId>
+									<artifactId>jmh-generator-annprocess</artifactId>
+									<version>${jmh.version}</version>
+								</path>
+							</annotationProcessorPaths>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
@@ -118,6 +166,32 @@
 					<useSystemClassLoader>false</useSystemClassLoader>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>${maven-assembly-plugin.version}</version>
+				<configuration>
+					<descriptor>src/main/assembly/perf-tests.xml</descriptor>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<attach>true</attach>
+							<archive>
+								<manifest>
+									<mainClass>org.openjdk.jmh.Main</mainClass>
+								</manifest>
+							</archive>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 	<profiles>
@@ -149,7 +223,7 @@
 						<configuration>
 							<aggregate>true</aggregate>
 							<additionalparam>-Xdoclint:none</additionalparam>
-							<additionalOptions>-Xdoclint:none</additionalOptions>
+<!--							<additionalOptions>-Xdoclint:none</additionalOptions>-->
 						</configuration>
 						<executions>
 							<execution>

--- a/src/main/assembly/perf-tests.xml
+++ b/src/main/assembly/perf-tests.xml
@@ -1,0 +1,28 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>perf-tests</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>test</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/test/perf/redisearch/client/DocumentIngestionBenchmark.java
+++ b/src/test/perf/redisearch/client/DocumentIngestionBenchmark.java
@@ -1,0 +1,176 @@
+package redisearch.client;
+
+import io.redisearch.Document;
+import io.redisearch.Schema;
+import io.redisearch.client.Client;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.ThreadParams;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Each thread will have a dedicated JRediSearch client.
+ */
+@BenchmarkMode({Mode.Throughput})
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class DocumentIngestionBenchmark {
+
+    static final Logger LOG = LoggerFactory.getLogger(Main.class);
+    static final int RANDOM_SEED = 12345;
+    static final int JREDISCLIENT_TIMEOUT = 500;
+    static final int JREDISCLIENT_POOLSIZE = 100;
+    static final int MULTIDOCUMENT_SIZE = 10;
+    static final int DOCS_SIZE = 10000;
+    static final String INDEX_NAME = "indexName";
+    static final String HOST_IP = "127.0.0.1";
+    static final int HOST_PORT = 6379;
+
+    static Options opt;
+
+    private io.redisearch.client.Client client;
+    private Jedis jedis_client;
+
+    /*
+     * ============================== HOW TO RUN THIS TEST: ====================================
+     *
+     * You can run this test:
+     *
+     * a) Via the command line:
+     *    $ mvn clean install
+     *    $ java -jar target/jredisearch-1.1.0-SNAPSHOT-perf-tests.jar -wi 1 -i 5 -t 16 -f 5
+     *    (we requested 1 warmup iterations, 5 iterations, 8 threads, and 5 forks)
+     *
+     */
+    public static void main(String[] args) throws RunnerException {
+
+        opt = new OptionsBuilder()
+                .include(DocumentIngestionBenchmark.class.getSimpleName())
+                .warmupIterations(1)
+                .measurementIterations(5)
+                .threads(4)
+                .forks(5)
+                .build();
+
+        new Runner(opt).run();
+
+    }
+
+    @Setup
+    public void setup(BenchmarkParams params) {
+
+        client = new Client(INDEX_NAME, HOST_IP, HOST_PORT, JREDISCLIENT_TIMEOUT, JREDISCLIENT_POOLSIZE);
+        jedis_client = new Jedis(HOST_IP, HOST_PORT);
+        jedis_client.flushAll();
+        client.dropIndex(true);
+
+        LOG.info("Started Creating Schema");
+        Schema sc = new Schema();
+        sc.addSortableTextField("name", 1.0);
+        sc.addSortableNumericField("count");
+        sc.addSortableNumericField("height");
+        sc.addSortableNumericField("height2");
+        sc.addSortableNumericField("height3");
+        sc.addSortableNumericField("height4");
+        sc.addSortableNumericField("height5");
+        sc.addSortableNumericField("height6");
+        sc.addSortableNumericField("height7");
+        sc.addSortableNumericField("height8");
+        sc.addSortableNumericField("height9");
+        sc.addSortableNumericField("height10");
+        sc.addSortableNumericField("height11");
+        sc.addSortableNumericField("height12");
+        client.createIndex(sc, Client.IndexOptions.defaultOptions());
+        LOG.info("Finished Creating Schema");
+        client.close();
+
+
+    }
+
+    @TearDown(Level.Trial)
+    public void doTearDown() {
+        //clean the db after the benchmark
+        jedis_client = new Jedis(HOST_IP, HOST_PORT, 30000);
+        jedis_client.flushAll();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(1)
+    public void Client_addDocument(NumericValues numv) {
+        numv.client.addDocument(new Document(String.format("multidoc:thread%d:%d", numv.id, numv.docPos), numv.fieldsList.get(numv.random.nextInt(DOCS_SIZE)))
+        );
+        numv.docPos++;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(MULTIDOCUMENT_SIZE)
+    public void Client_addDocuments(NumericValues numv) {
+        List<Document> docs = new ArrayList<Document>();
+        for (int i = 0; i < MULTIDOCUMENT_SIZE; i++) {
+            docs.add(new Document(String.format("multidoc:thread%d:%d", numv.id, numv.docPos), numv.fieldsList.get(numv.random.nextInt(DOCS_SIZE))));
+            numv.docPos++;
+        }
+        numv.client.addDocuments(docs.toArray(new Document[docs.size()]));
+
+    }
+
+    @State(Scope.Thread)
+    public static class NumericValues {
+        Random random;
+        private int id;
+        private io.redisearch.client.Client client;
+        private int docPos;
+        private List<Map<String, Object>> fieldsList;
+
+
+        @Setup
+        public void setup(ThreadParams threads) {
+            client = new Client(INDEX_NAME, HOST_IP, HOST_PORT, JREDISCLIENT_TIMEOUT, JREDISCLIENT_POOLSIZE);
+            id = threads.getThreadIndex();
+            random = new Random();
+            random.setSeed(RANDOM_SEED);
+            docPos = 0;
+            LOG.info("Started Creating FieldsList");
+
+            fieldsList = new ArrayList<Map<String, Object>>();
+            for (int i = 0; i < DOCS_SIZE; i++) {
+                Map<String, Object> fields = new HashMap<>();
+
+                fields.put("count", random.nextFloat());
+                fields.put("height", random.nextFloat());
+                fields.put("height2", random.nextFloat());
+                fields.put("height3", random.nextFloat());
+                fields.put("height4", random.nextFloat());
+                fields.put("height5", random.nextFloat());
+                fields.put("height6", random.nextFloat());
+                fields.put("height7", random.nextFloat());
+                fields.put("height8", random.nextFloat());
+                fields.put("height9", random.nextFloat());
+                fields.put("height10", random.nextFloat());
+                fields.put("height11", random.nextFloat());
+                fields.put("height12", random.nextFloat());
+                fieldsList.add(fields);
+            }
+            LOG.info("Finished Creating FieldsList");
+
+        }
+
+        @TearDown(Level.Trial)
+        public void doTearDown() {
+        }
+
+
+    }
+
+
+}


### PR DESCRIPTION
[add] added jmh microbenchmark for document ingestion
[upg] bumped jedis version from 3.01 to 3.1.0 ( to access sendCommand on Pipeline)
[add] changed addDocuments to make usage of pipelining ( see Client_addDocuments vs Client_addDocument microbenchmark ), **leading to 16.4K OPS with Client_addDocument vs 18.3K OPS with Client_addDocuments**

-------


## Client_addDocuments vs Client_addDocument microbenchmark

OSS redis-server + RediSearch ( current master ) runned with the following configs
```
redis-server --protected-mode no --save "" --appendonly no --loadmodule ./redisearch.so
```

Benchmark runned via:
```
$ mvn clean package
java -jar target/jredisearch-1.1.0-SNAPSHOT-perf-tests.jar -wi 0 -i 1 -t 16 -f 1 -r 30
```
output:
```
(...)
Benchmark                                        Mode  Cnt      Score   Error  Units
DocumentIngestionBenchmark.Client_addDocument   thrpt       16400.254          ops/s
DocumentIngestionBenchmark.Client_addDocuments  thrpt       18299.231          ops/s
```