### PR TITLE
Issue 91 null values

### DIFF
--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -489,16 +489,14 @@ public class Client implements io.redisearch.Client {
 
         args.add(Keywords.FIELDS.getRaw());
         String key = null;
-        try {
-            for (Map.Entry<String, Object> ent : doc.getProperties()) {
-                key = ent.getKey();
-                args.add(SafeEncoder.encode(key));
-                Object value = ent.getValue();
-                args.add(value instanceof byte[] ?  (byte[])value :  SafeEncoder.encode(value.toString()));
+        for (Map.Entry<String, Object> ent : doc.getProperties()) {
+            key = ent.getKey();
+            args.add(SafeEncoder.encode(key));
+            Object value = ent.getValue();
+            if (value == null) {
+                throw new NullPointerException( "Document attribute '"+ key +"' is null. (Remove it, or set a value)" );
             }
-        }catch (NullPointerException npe) {
-            // A value cannot be null
-            throw new JedisDataException( "Document attribute '"+ key +"' is null. (Remove it, or set a value)" );
+            args.add(value instanceof byte[] ?  (byte[])value :  SafeEncoder.encode(value.toString()));
         }
 
         return sendCommand(conn, commands.getAddCommand(), args.toArray(new byte[args.size()][])); 

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -488,10 +488,17 @@ public class Client implements io.redisearch.Client {
         }
 
         args.add(Keywords.FIELDS.getRaw());
-        for (Map.Entry<String, Object> ent : doc.getProperties()) {
-            args.add(SafeEncoder.encode(ent.getKey()));
-            Object value = ent.getValue();
-            args.add(value instanceof byte[] ?  (byte[])value :  SafeEncoder.encode(value.toString()));
+        String key = null;
+        try {
+            for (Map.Entry<String, Object> ent : doc.getProperties()) {
+                key = ent.getKey();
+                args.add(SafeEncoder.encode(key));
+                Object value = ent.getValue();
+                args.add(value instanceof byte[] ?  (byte[])value :  SafeEncoder.encode(value.toString()));
+            }
+        }catch (NullPointerException npe) {
+            // A value cannot be null
+            throw new JedisDataException( "Document attribute '"+ key +"' is null. (Remove it, or set a value)" );
         }
 
         return sendCommand(conn, commands.getAddCommand(), args.toArray(new byte[args.size()][])); 

--- a/src/test/java/io/redisearch/client/ClientTest.java
+++ b/src/test/java/io/redisearch/client/ClientTest.java
@@ -354,8 +354,8 @@ public class ClientTest {
 
         try {
             cl.addDocument("doc2", fields);
-            fail("Should throw a 'JedisDataException'.");
-        } catch (JedisDataException e) {
+            fail("Should throw a 'NullPointerException'.");
+        } catch (NullPointerException e) {
             assertEquals("Document attribute 'tag' is null. (Remove it, or set a value)" , e.getMessage());
         }
 
@@ -369,8 +369,8 @@ public class ClientTest {
         fields.put("release_year", null);
         try {
             cl.addDocument("doc2", fields);
-            fail("Should throw a 'JedisDataException'.");
-        } catch (JedisDataException e) {
+            fail("Should throw a 'NullPointerException'.");
+        } catch (NullPointerException e) {
             assertEquals("Document attribute 'release_year' is null. (Remove it, or set a value)" , e.getMessage());
         }
         res = cl.search(new Query("title"));

--- a/src/test/java/io/redisearch/client/ClientTest.java
+++ b/src/test/java/io/redisearch/client/ClientTest.java
@@ -354,7 +354,7 @@ public class ClientTest {
 
         try {
             cl.addDocument("doc2", fields);
-            fail("Should throw a 'Null Pointer Exception'.");
+            fail("Should throw a 'JedisDataException'.");
         } catch (JedisDataException e) {
             assertEquals("Document attribute 'tag' is null. (Remove it, or set a value)" , e.getMessage());
         }
@@ -369,7 +369,7 @@ public class ClientTest {
         fields.put("release_year", null);
         try {
             cl.addDocument("doc2", fields);
-            fail("Should throw a 'Null Pointer Exception'.");
+            fail("Should throw a 'JedisDataException'.");
         } catch (JedisDataException e) {
             assertEquals("Document attribute 'release_year' is null. (Remove it, or set a value)" , e.getMessage());
         }


### PR DESCRIPTION
…with clear message instead of NPE

* after the discussion we chose to NOT change the map (neither replacing the null value with `""` or removing the null entries
* but to raise an exception

* I have chosen to raise a JedisDataException with a clear message (instead of NPE), the message associated with the exception is"

`"Document attribute '+  attributes  +' is null. (Remove it, or set a value)"`