### PR TITLE
Update GeoValue.java Unit enum wrong value

### DIFF
--- a/src/main/java/io/redisearch/querybuilder/GeoValue.java
+++ b/src/main/java/io/redisearch/querybuilder/GeoValue.java
@@ -8,7 +8,7 @@ public class GeoValue extends Value {
         KILOMETERS("km"),
         METERS("m"),
         FEET("ft"),
-        MILES("m");
+        MILES("mi");
 
         private final String unit;
         Unit(String unit) {


### PR DESCRIPTION
GeoValue.Unit.MILES value was wrong as "m", changed to "mi" regarding RediSearch documentation.