### PR TITLE
Merged in the latest release used in java projects

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -33,14 +32,14 @@ jobs:
 
       - name: Install gpg key
         run: |
-          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          cat <(echo -e "${{ secrets.OSSH_GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
 
       - name: Publish
         run: |
           mvn --no-transfer-progress \
             --batch-mode \
-            -Dgpg.passphrase='${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}' \
+            -Dgpg.passphrase='${{ secrets.OSSH_GPG_SECRET_KEY_PASSWORD }}' \
             -DskipTests deploy -P release
         env:
           MAVEN_USERNAME: ${{secrets.OSSH_USERNAME}}

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -19,10 +19,6 @@ jobs:
           realversion="${realversion//v/}"
           echo "::set-output name=VERSION::$realversion"
 
-      - name: set version from tag
-        uses: actions/setup-java@v2
-        run: mvn versions:set -DnewVersion=${{ steps.get_version.outputs.VERSION }}
-
       - name: Set up publishing to maven central
         uses: actions/setup-java@v2
         with:
@@ -31,6 +27,9 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+
+      - name: mvn versions
+        run: mvn versions:set -DnewVersion=${{ steps.get_version.outputs.VERSION }}
 
       - name: Install gpg key
         run: |


### PR DESCRIPTION
JRediSearch was missing the on publish. It now uses OSSH not OSSRH, like the others.