### PR TITLE
Spring Integration PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !.circleci/**
 .idea/
 target
+bin

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -21,6 +21,7 @@ public class Client implements io.redisearch.Client {
     private final String indexName;
     private final byte[] endocdedIndexName;
     private final Pool<Jedis> pool;
+    private Jedis jedis;
 
     protected Commands.CommandProvider commands;
     
@@ -36,6 +37,14 @@ public class Client implements io.redisearch.Client {
       this.pool = pool;
       this.commands = new Commands.SingleNodeCommands();
     }
+    
+    public Client(String indexName, Jedis jedis) {
+        this.indexName = indexName;
+        this.endocdedIndexName = SafeEncoder.encode(indexName);
+        this.jedis = jedis;
+        this.pool = null;
+        this.commands = new Commands.SingleNodeCommands();
+      }
     
     /**
      * Create a new client to a RediSearch index
@@ -141,7 +150,7 @@ public class Client implements io.redisearch.Client {
     
     @Override
     public Jedis connection() {
-        return pool.getResource();
+        return jedis != null ? jedis : pool.getResource();
     }
 
     private BinaryClient sendCommand(Jedis conn, ProtocolCommand provider, String... args) {

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -1241,6 +1241,11 @@ public class Client implements io.redisearch.Client {
     
     @Override
     public void close() {
-      this.pool.close();
+      if (pool != null) {
+        pool.close();
+      }
+      if (jedis != null) {
+        jedis.close();
+      }
     }
 }

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -21,7 +21,7 @@ public class Client implements io.redisearch.Client {
     private final String indexName;
     private final byte[] endocdedIndexName;
     private final Pool<Jedis> pool;
-    private Jedis jedis;
+    private final Jedis jedis;
 
     protected Commands.CommandProvider commands;
     


### PR DESCRIPTION
This PR allows JRediSearch to:

- be instantiated used a Jedis instance (for envs that manage and serve their own connections, a.k.a. Spring)