### PR TITLE
Replacement PR - Spring Integration PR #171 is not picking up fork changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 !.circleci/**
 .idea/
 target
-bin

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 !.circleci/**
 .idea/
 target
+bin

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -287,6 +287,7 @@ public class Client implements io.redisearch.Client {
      *
      * @return all configs map
      */
+    @SuppressWarnings("unchecked")
     @Override
     public Map<String, String> getAllConfig() {
         try (Jedis conn = connection()) {

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -21,6 +21,7 @@ public class Client implements io.redisearch.Client {
     private final String indexName;
     private final byte[] endocdedIndexName;
     private final Pool<Jedis> pool;
+    private Jedis jedis;
 
     protected Commands.CommandProvider commands;
     
@@ -36,6 +37,14 @@ public class Client implements io.redisearch.Client {
       this.pool = pool;
       this.commands = new Commands.SingleNodeCommands();
     }
+    
+    public Client(String indexName, Jedis jedis) {
+        this.indexName = indexName;
+        this.endocdedIndexName = SafeEncoder.encode(indexName);
+        this.jedis = jedis;
+        this.pool = null;
+        this.commands = new Commands.SingleNodeCommands();
+      }
     
     /**
      * Create a new client to a RediSearch index
@@ -141,7 +150,7 @@ public class Client implements io.redisearch.Client {
     
     @Override
     public Jedis connection() {
-        return pool.getResource();
+        return jedis != null ? jedis : pool.getResource();
     }
 
     private BinaryClient sendCommand(Jedis conn, ProtocolCommand provider, String... args) {

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -21,7 +21,7 @@ public class Client implements io.redisearch.Client {
     private final String indexName;
     private final byte[] endocdedIndexName;
     private final Pool<Jedis> pool;
-    private Jedis jedis;
+    private final Jedis jedis;
 
     protected Commands.CommandProvider commands;
     
@@ -34,6 +34,7 @@ public class Client implements io.redisearch.Client {
     public Client(String indexName, Pool<Jedis> pool) {
       this.indexName = indexName;
       this.endocdedIndexName = SafeEncoder.encode(indexName);
+      this.jedis = null;
       this.pool = pool;
       this.commands = new Commands.SingleNodeCommands();
     }

--- a/src/main/java/io/redisearch/client/Client.java
+++ b/src/main/java/io/redisearch/client/Client.java
@@ -1241,6 +1241,11 @@ public class Client implements io.redisearch.Client {
     
     @Override
     public void close() {
-      this.pool.close();
+      if (pool != null) {
+        pool.close();
+      }
+      if (jedis != null) {
+        jedis.close();
+      }
     }
 }

--- a/src/test/java/io/redisearch/client/ClientTest.java
+++ b/src/test/java/io/redisearch/client/ClientTest.java
@@ -4,9 +4,9 @@ import io.redisearch.*;
 import io.redisearch.Schema.TagField;
 import io.redisearch.Schema.TextField;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.util.SafeEncoder;
-import redis.clients.jedis.Protocol;
 
 import java.util.Arrays;
 import java.util.HashMap;


### PR DESCRIPTION
This PR allows JRediSearch to:

- be instantiated used a Jedis instance (for envs that manage and serve their own connections, a.k.a. Spring)